### PR TITLE
Level map flag

### DIFF
--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/controller/UserRestController.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/controller/UserRestController.java
@@ -135,4 +135,16 @@ public class UserRestController {
         }
     }
 
+    /*--------------------------Update--------------------------- */
+    @GetMapping("/user/flag")
+    public Response<Boolean> resetFlag(@Validated @RequestParam("userId") String userId) {
+        try {
+            userService.flagNullify(userId);
+            return ResponseCreator.succeed(true);
+        } catch (Exception e) {
+            return ResponseCreator.fail(USER_DOES_NOT_EXIST, new UserValidationException(USER_DOES_NOT_EXIST,
+                    "get userDailyDto", String.format("userId : %s doesn't exits", userId)), null);
+        }
+    }
+
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/dto/UserDto.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/dto/UserDto.java
@@ -15,6 +15,8 @@ public class UserDto {
     int level;// レベル
     double nextLevelPercentage;// 次のレベルまでの割合
     int levelRate;// 1レベルあげるために必要なポイント
+    Boolean levelFlag;//レベルアップフラグ
+    Boolean mapFlag;//マップ解放フラグ
 
     public static UserDto build(User user) {
         UserDto dto = new UserDto();
@@ -25,6 +27,8 @@ public class UserDto {
         dto.nextLevelPercentage = (double) (user.getTotalPoint() % Rule.levelRate) / Rule.levelRate;
         // System.out.println(dto.nextLevelPercentage);
         dto.levelRate = Rule.levelRate;
+        dto.levelFlag = user.getLevelFlag();
+        dto.mapFlag = user.getMapFlag();
         return dto;
     }
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/dto/UserForm.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/application/dto/UserForm.java
@@ -14,7 +14,7 @@ public class UserForm {
     String password;
     int age;
     public User toEntity(){
-        User user = new User(userId,password,age,0);
+        User user = new User(userId,password,age,0,false,false);
         return user;
     }
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/entity/User.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/entity/User.java
@@ -22,4 +22,6 @@ public class User {
     String password;//パスワード
     int age; // 年齢
     int totalPoint;//累積ポイント
+    Boolean levelFlag;//レベルアップフラグ
+    Boolean mapFlag;//マップ解放フラグ
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MapService.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MapService.java
@@ -6,7 +6,6 @@ import jp.kobespiral.sandazerocarbonappbackend.application.dto.MapDto;
 import jp.kobespiral.sandazerocarbonappbackend.domain.entity.Map;
 import jp.kobespiral.sandazerocarbonappbackend.domain.repository.InitialLocationRepository;
 import jp.kobespiral.sandazerocarbonappbackend.domain.repository.MapRepository;
-import jp.kobespiral.sandazerocarbonappbackend.domain.utils.Rule;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -35,7 +34,7 @@ public class MapService {
      * @return マップのDto
      */
     public MapDto getMap(String userId, int currentLocation) {
-        int stage = userService.calculateStage(userId);//ステージを計算
+        int stage = userService.calculateStage(userId);// ステージを計算
 
         Map map = mapRepository.findByCurrentLocationAndStage(currentLocation, stage); // 特定ユーザーのレベルと現在地からマップを取得
 
@@ -49,12 +48,11 @@ public class MapService {
      * @return MapDto
      */
     public MapDto getMapOnInitialLocation(String userId) {
-        int stage = userService.calculateStage(userId);//ステージを計算
+        int stage = userService.calculateStage(userId);// ステージを計算
 
         Map map = mapRepository.findByCurrentLocationAndStage(
                 initialLocationRepository.findFirstByStage(stage).getInitialLocation(), stage); // 特定ユーザーのレベルから初期位置のマップを取得
 
         return MapDto.build(userId, map);
     }
-
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MapService.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MapService.java
@@ -35,15 +35,7 @@ public class MapService {
      * @return マップのDto
      */
     public MapDto getMap(String userId, int currentLocation) {
-        int caluculatedStage = userService.getUserDto(userId).getLevel() / Rule.mapLevelRate + 1; // マップの段階を計算
-
-        int stage; // ユーザーの現在のステージ
-
-        if (caluculatedStage > Rule.maxStage) { // 計算したステージが最大値を超えていたら
-            stage = Rule.maxStage; // ステージの最大値に設定
-        } else {
-            stage = caluculatedStage; // 計算したステージに設定
-        }
+        int stage = userService.calculateStage(userId);//ステージを計算
 
         Map map = mapRepository.findByCurrentLocationAndStage(currentLocation, stage); // 特定ユーザーのレベルと現在地からマップを取得
 
@@ -57,19 +49,12 @@ public class MapService {
      * @return MapDto
      */
     public MapDto getMapOnInitialLocation(String userId) {
-        int caluculatedStage = userService.getUserDto(userId).getLevel() / Rule.mapLevelRate + 1; // マップの段階を計算
-
-        int stage; // ユーザーの現在のステージ
-
-        if (caluculatedStage > Rule.maxStage) { // 計算したステージが最大値を超えていたら
-            stage = Rule.maxStage; // ステージの最大値に設定
-        } else {
-            stage = caluculatedStage; // 計算したステージに設定
-        }
+        int stage = userService.calculateStage(userId);//ステージを計算
 
         Map map = mapRepository.findByCurrentLocationAndStage(
                 initialLocationRepository.findFirstByStage(stage).getInitialLocation(), stage); // 特定ユーザーのレベルから初期位置のマップを取得
 
         return MapDto.build(userId, map);
     }
+
 }

--- a/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MissionManagementService.java
+++ b/sanda-zero-carbon-app-backend/src/main/java/jp/kobespiral/sandazerocarbonappbackend/domain/service/MissionManagementService.java
@@ -45,11 +45,11 @@ public class MissionManagementService {
      */
     public MissionDto createMission(MissionForm form) {
         Mission mission = form.toEntity();
-        missionRepository.save(mission);
         Tag tag = tagRepository.findById(mission.getTagId())
                 .orElseThrow(() -> new MissionValidationException(NO_TAG_CORRESPONDING_TO_THE_MISSION,
                         "get tag from the mission",
                         String.format("missionId; %d does not have tag", mission.getMissionId())));
+        missionRepository.save(mission);
         return MissionDto.build(mission, tag);
     }
 


### PR DESCRIPTION
●レベルアップフラグとマップ解放フラグを実装しました。
これらはレベルアップ時/マップ解放時にフロントでそういった演出をするために使用する
なので、フロントではUserDto取得して演出後、上記2つのフラグをFalseにするための関数を呼ぶ必要がある。(ユーザコントローラのresetFlag())

レビュー方法
1.ミッションクリアしてレベルアップ時にレベルアップフラグが立つか
2.ミッションクリアしてマップ解放時にマップ解放フラグが立つか
3.クイズクリアしてレベルアップ時にレベルアップフラグが立つか
4.クイズクリアしてマップ解放時にマップ解放フラグが立つか
5.上記4つに対して、フラグをFalseにするための関数を呼んでフラグがFalseになるかの確認。(ユーザコントローラのresetFlag())

あと追加でマップ機能に支障出てないか確認してほしい